### PR TITLE
topic/tradebot#7 order fixed quote qty

### DIFF
--- a/src/apps/tests/Binance_tests.cpp
+++ b/src/apps/tests/Binance_tests.cpp
@@ -79,6 +79,7 @@ SCENARIO("Raw Websocket use", "[binance][net][websocket][live]")
                     symbol,
                     binance::Side::SELL,
                     0.001,
+                    binance::QuantityUnit::Base,
                     clientId,
                 };
                 REQUIRE(binance.placeOrderTrade(order).status == 200);
@@ -147,6 +148,7 @@ SCENARIO("Raw Websocket use", "[binance][net][websocket][live]")
                 symbol,
                 binance::Side::BUY,
                 0.001,
+                binance::QuantityUnit::Base,
                 clientId, // we can reuse it, since the order did complete
             };
             REQUIRE(binance.placeOrderTrade(order).status == 200);

--- a/src/apps/tests/Binance_tests.cpp
+++ b/src/apps/tests/Binance_tests.cpp
@@ -30,6 +30,67 @@ SCENARIO("Binance REST API", "[binance][net][live]")
     }
 }
 
+
+SCENARIO("Binance REST API quote order quantity", "[binance][api]")
+{
+    GIVEN("A Binance interface connected to the testnet") 
+    {
+        binance::Api binance{secret::gTestnetCredentials};
+
+        // The nominal value on testnet as of 2023/12/22.
+        const Decimal quoteQuantity = 5;
+
+        GIVEN("A market order, with quantity expressed in quote")
+        {
+            binance::MarketOrder marketOrder{
+                binance::OrderBase{
+                    "BTCUSDT",
+                    binance::Side::BUY,
+                    quoteQuantity,
+                    binance::QuantityUnit::Quote,
+                    binance::ClientId{"apitest_limit_order"},
+                },
+                binance::Type::MARKET,
+            };
+
+            THEN("The order can execute")
+            {
+                binance::Response orderResponse = binance.placeOrderTrade(marketOrder);
+                CHECK(orderResponse.status == 200);
+            }
+        }
+
+        GIVEN("A market order, with quantity expressed in quote")
+        {
+            binance::LimitOrder limitOrder{
+                binance::OrderBase{
+                    "BTCUSDT",
+                    binance::Side::BUY,
+                    quoteQuantity,
+                    binance::QuantityUnit::Quote,
+                    binance::ClientId{"apitest_limit_order"},
+                },
+                4000,
+                binance::TimeInForce::FOK,
+                binance::Type::LIMIT,
+            };
+
+            THEN("The order can NOT execute")
+            {
+                binance::Response orderResponse = binance.placeOrderTrade(limitOrder);
+                INFO("Response: " << orderResponse.json->dump(2));
+                // IMPORTANT: A 200 here would be good news,
+                // meaning Binance finally implemented quote quantity on limit FOK orders.
+                REQUIRE(orderResponse.status == 400);
+                CHECK(orderResponse.json->at("code") == -1106);
+                CHECK(orderResponse.json->at("msg") == "Parameter 'quoteOrderQty' sent when not required.");
+            }
+        }
+    }
+
+}
+
+
 SCENARIO("Raw Websocket use", "[binance][net][websocket][live]")
 {
     GIVEN("A websocket reading a single message")

--- a/src/apps/tests/Trader_tests.cpp
+++ b/src/apps/tests/Trader_tests.cpp
@@ -50,10 +50,13 @@ SCENARIO("Radical initialization clean-up", "[trader]")
         {
             binance::ClientId id{"testdog01"};
             binance::LimitOrder impossibleOrder{
-                pair.symbol(),
-                binance::Side::SELL,
-                0.01, // qty
-                id,
+                binance::OrderBase{
+                    pair.symbol(),
+                    binance::Side::SELL,
+                    0.01, // qty
+                    binance::QuantityUnit::Base,
+                    id,
+                },
                 floor(averagePrice * 4),  // price
             };
             binance.restApi.placeOrderTrade(impossibleOrder);

--- a/src/libs/binance/binance/Orders.h
+++ b/src/libs/binance/binance/Orders.h
@@ -137,11 +137,20 @@ private:
     std::string mId;
 };
 
+
+enum class QuantityUnit
+{
+    Base,
+    Quote,
+};
+
+
 struct OrderBase
 {
     Symbol symbol;
     Side side;
     Decimal quantity;
+    QuantityUnit unit = QuantityUnit::Base;
     ClientId clientId;
 };
 

--- a/src/libs/binance/binance/detail/OrdersHelpers.h
+++ b/src/libs/binance/binance/detail/OrdersHelpers.h
@@ -5,10 +5,28 @@
 
 #include <cpr/cpr.h>
 
+#include <spdlog/spdlog.h>
+
 
 namespace ad {
 namespace binance {
 namespace detail {
+
+
+inline const char * getQuantityKey(const OrderBase & aOrder)
+{
+    switch(aOrder.unit)
+    {
+        case QuantityUnit::Base:
+            return "quantity";
+        case QuantityUnit::Quote:
+            return "quoteOrderQty";
+        default:
+            spdlog::warn("Order quantity unit unknown '{}', assuming 'base'.",
+                         static_cast<int>(aOrder.unit));
+            return "quantity";
+    }
+}
 
 
 inline cpr::Parameters initParameters(const MarketOrder & aOrder)
@@ -16,7 +34,7 @@ inline cpr::Parameters initParameters(const MarketOrder & aOrder)
     return {
             {"symbol", aOrder.symbol},
             {"side", to_string(aOrder.side)},
-            {"quantity", to_str(aOrder.quantity)},
+            {getQuantityKey(aOrder), to_str(aOrder.quantity)},
             {"newClientOrderId", static_cast<const std::string &>(aOrder.clientId)},
             {"type", to_string(aOrder.type)}
     };
@@ -28,7 +46,7 @@ inline cpr::Parameters initParameters(const LimitOrder & aOrder)
     return {
             {"symbol", aOrder.symbol},
             {"side", to_string(aOrder.side)},
-            {"quantity", to_str(aOrder.quantity)},
+            {getQuantityKey(aOrder), to_str(aOrder.quantity)},
             {"newClientOrderId", static_cast<const std::string &>(aOrder.clientId)},
             {"price", to_str(aOrder.price)},
             {"timeInForce", to_string(aOrder.timeInForce)},

--- a/src/libs/tradebot/tradebot/Database.h
+++ b/src/libs/tradebot/tradebot/Database.h
@@ -68,9 +68,11 @@ public:
     std::vector<Decimal> getSellRatesBelow(Decimal aRateLimit, const Pair & aPair);
     std::vector<Decimal> getBuyRatesAbove(Decimal aRateLimit, const Pair & aPair);
 
-    /// \brief Will call either `getSellRatesBelow()` or `getBuyRatesAbove()` depending on `aSide`.
+    /// \brief Will call either `getSellRatesBelow()` or `getBuyRatesAbove()` depending on `aSide`,
+    /// returning fragments with a profitable rate present in the DB.
     std::vector<Decimal> getProfitableRates(Side aSide, Decimal aRateLimit, const Pair & aPair);
 
+    /// \brief Assign to `aOrder` all unasigned fragments matching said order.
     void assignAvailableFragments(const Order & aOrder);
 
     /// \brief Sum the amounts of all fragments in the database.

--- a/src/libs/tradebot/tradebot/Exchange.cpp
+++ b/src/libs/tradebot/tradebot/Exchange.cpp
@@ -165,6 +165,7 @@ binance::Response placeOrderImpl(const T_order & aBinanceOrder, Order & aOrder, 
 }
 
 // Place order returns 400 -1013 if the price is above the symbol limit.
+// \deprecated Uses the order fragment rate as order price limit, which is mixing two concepts
 Order & Exchange::placeOrder(Order & aOrder, Execution aExecution)
 {
     binance::Response response;
@@ -174,10 +175,10 @@ Order & Exchange::placeOrder(Order & aOrder, Execution aExecution)
             response = placeOrderImpl(to_marketOrder(aOrder), aOrder, restApi);
             break;
         case Execution::Limit:
-            response = placeOrderImpl(to_limitOrder(aOrder), aOrder, restApi);
+            response = placeOrderImpl(to_limitOrder(aOrder, aOrder.fragmentsRate), aOrder, restApi);
             break;
         case Execution::LimitFok:
-            response = placeOrderImpl(to_limitFokOrder(aOrder), aOrder, restApi);
+            response = placeOrderImpl(to_limitFokOrder(aOrder, aOrder.fragmentsRate), aOrder, restApi);
             break;
     }
 
@@ -253,13 +254,9 @@ std::optional<FulfilledOrder> Exchange::fillMarketOrder(Order & aOrder)
 
 
 std::optional<FulfilledOrder> Exchange::fillLimitFokOrder(Order & aOrder,
-                                                          std::optional<Decimal> aExplicitLimitRate)
+                                                          Decimal aLimitPrice)
 {
-    binance::LimitOrder limitOrder = to_limitFokOrder(aOrder);
-    if (aExplicitLimitRate)
-    {
-        limitOrder.price = *aExplicitLimitRate;
-    }
+    binance::LimitOrder limitOrder = to_limitFokOrder(aOrder, aLimitPrice);
     return fillOrderImpl(limitOrder, aOrder, restApi, "limit fok");
 }
 

--- a/src/libs/tradebot/tradebot/Exchange.h
+++ b/src/libs/tradebot/tradebot/Exchange.h
@@ -45,7 +45,7 @@ struct Exchange
     std::optional<FulfilledOrder> fillMarketOrder(Order & aOrder);
 
     std::optional<FulfilledOrder> fillLimitFokOrder(Order & aOrder,
-                                                    std::optional<Decimal> aExplicitLimitRate = {});
+                                                    Decimal aLimitPrice);
 
     /// \return true if the order was cancelled, false otherwise
     ///         (because it was not present, already cancelled, etc.).

--- a/src/libs/tradebot/tradebot/Order.h
+++ b/src/libs/tradebot/tradebot/Order.h
@@ -44,6 +44,8 @@ struct Order
     std::string traderName;
     Coin base;
     Coin quote;
+    // TODO: Ideally, we want to be able to set the amout to be in base or quote (see binance::OrderBase)
+    // But at the moment FOK orders only accept quantity in base, so we did not bother.
     Decimal baseAmount; // Quantity of base to exchange
     Decimal fragmentsRate; // This order was spawned from 1..n fragments at this rate.
                            // IMPORTANT: This is not necessarily the price at which this order will be issued!
@@ -96,6 +98,7 @@ inline binance::MarketOrder to_marketOrder(const Order & aOrder)
         aOrder.symbol(),
         (aOrder.side == Side::Sell ? binance::Side::SELL : binance::Side::BUY),
         aOrder.baseAmount,
+        binance::QuantityUnit::Base,
         aOrder.clientId(),
     };
 }
@@ -108,6 +111,7 @@ inline binance::LimitOrder to_limitOrder(const Order & aOrder, Decimal aLimitRat
             aOrder.symbol(),
             (aOrder.side == Side::Sell ? binance::Side::SELL : binance::Side::BUY),
             aOrder.baseAmount,
+            binance::QuantityUnit::Base,
             aOrder.clientId(),
         },
         aLimitRate,

--- a/src/libs/tradebot/tradebot/Order.h
+++ b/src/libs/tradebot/tradebot/Order.h
@@ -101,7 +101,7 @@ inline binance::MarketOrder to_marketOrder(const Order & aOrder)
 }
 
 
-inline binance::LimitOrder to_limitOrder(const Order & aOrder)
+inline binance::LimitOrder to_limitOrder(const Order & aOrder, Decimal aLimitRate)
 {
     return {
         binance::OrderBase{
@@ -110,13 +110,13 @@ inline binance::LimitOrder to_limitOrder(const Order & aOrder)
             aOrder.baseAmount,
             aOrder.clientId(),
         },
-        aOrder.fragmentsRate,
+        aLimitRate,
     };
 }
 
-inline binance::LimitOrder to_limitFokOrder(const Order & aOrder)
+inline binance::LimitOrder to_limitFokOrder(const Order & aOrder, Decimal aLimitRate)
 {
-    binance::LimitOrder order = to_limitOrder(aOrder);
+    binance::LimitOrder order = to_limitOrder(aOrder, aLimitRate);
     order.timeInForce = binance::TimeInForce::FOK;
     return order;
 }


### PR DESCRIPTION
closes #7.
- Attempt to makes the distinction between limite rate and fragment rate.
- Add quantity unit on binance::Order, allowing Base (default) or Quote.
- Implement a test for orders with quantity expressed in Quote unit.
